### PR TITLE
fm: the gmrs profile's channels are 462 MHz, not 467

### DIFF
--- a/src/scanners/fm.py
+++ b/src/scanners/fm.py
@@ -93,7 +93,7 @@ BAND_PROFILES = {
     },
     "gmrs": {
         "name": "GMRS Repeater",
-        "description": "GMRS repeater outputs (467 MHz, 8 channels, 25 kHz)",
+        "description": "GMRS repeater outputs (462 MHz, 8 channels, 25 kHz)",
         "channels": {
             "RPT1": 462.5500e6, "RPT2": 462.5750e6,
             "RPT3": 462.6000e6, "RPT4": 462.6250e6,


### PR DESCRIPTION
The `gmrs` profile in `src/scanners/fm.py` is described as covering 467 MHz:

```python
"gmrs": {
    "name": "GMRS Repeater",
    "description": "GMRS repeater outputs (467 MHz, 8 channels, 25 kHz)",
    "channels": {
        "RPT1": 462.5500e6, "RPT2": 462.5750e6,
        ...
```

but every frequency in it is 462.5500–462.7250 MHz.

The **channels are correct**. GMRS repeater *outputs* are on 462.5500–462.7250, and
467.5500–467.7250 carries the repeater *inputs*. So the profile scans exactly what
it should — a receiver wants the output side, since that is where the repeater
transmits. Only the description is wrong.

It matters when picking a band to scan: "467 MHz" reads as though the profile
covers the input side, i.e. what handhelds transmit into a repeater, which is a
different measurement with a much smaller footprint. Someone choosing this
profile to catch repeater users would expect the wrong thing.

One-line description change; no behavioural difference.

